### PR TITLE
Solution for "flip-args" , "limit-function-call-count" and "math-fns"

### DIFF
--- a/js-exercises/flip-args/README.md
+++ b/js-exercises/flip-args/README.md
@@ -1,0 +1,25 @@
+# Instructions
+
+Create a function that invokes `func` with arguments reversed.
+
+```js
+var flipped = flipArgs(function() {
+  console.log(arguments);
+});
+ 
+flipped('a', 'b', 'c', 'd');
+// => ['d', 'c', 'b', 'a']
+```
+
+# Requirements
+
+### **What are some good real-life use cases for such a function?**
+Sorting
+
+### **What test cases can you add to the test file?**
+
+flipArgs.test.js
+
+
+# Restrictions
+- Don't use any libraries

--- a/js-exercises/flip-args/flipArgs.js
+++ b/js-exercises/flip-args/flipArgs.js
@@ -1,0 +1,8 @@
+function flipArgs(...args) {
+  const flippedArguments = [...args].reverse();
+  return flippedArguments;
+}
+
+export {
+  flipArgs,
+};

--- a/js-exercises/flip-args/flipArgs.test.js
+++ b/js-exercises/flip-args/flipArgs.test.js
@@ -8,3 +8,9 @@ describe('Flip the arguments', () => {
     expect(flipArgs('a', 'b', 'c', 'd', 'e')).toEqual(['e', 'd', 'c', 'b', 'a']);
   });
 });
+
+describe('Type Of flipArgs', () => {
+  it('should return object', () => {
+    expect(typeof flipArgs()).toBe('object');
+  });
+});

--- a/js-exercises/flip-args/flipArgs.test.js
+++ b/js-exercises/flip-args/flipArgs.test.js
@@ -1,0 +1,10 @@
+// write your own test cases
+/* eslint linebreak-style: ["error", "windows"] */
+import { flipArgs } from './flipArgs';
+
+describe('Flip the arguments', () => {
+  test('should flip the set of arguments', () => {
+    expect(flipArgs(1, 2, 3, 4, 5)).toEqual([5, 4, 3, 2, 1]);
+    expect(flipArgs('a', 'b', 'c', 'd', 'e')).toEqual(['e', 'd', 'c', 'b', 'a']);
+  });
+});

--- a/js-exercises/limit-function-call-count/README.md
+++ b/js-exercises/limit-function-call-count/README.md
@@ -1,0 +1,4 @@
+# Instructions
+
+Should return a function that invokes `cb`.
+The returned function should only allow `cb` to be invoked `n` times.

--- a/js-exercises/limit-function-call-count/limitFunctionCallCount.js
+++ b/js-exercises/limit-function-call-count/limitFunctionCallCount.js
@@ -1,0 +1,11 @@
+const limitFunctionCallCount = (callFunction, numberOfCalls) => {
+  let countForCalls = 0;
+  return (...input) => {
+    countForCalls += 1;
+    return (countForCalls <= numberOfCalls) ? callFunction(...input) : null;
+  };
+};
+
+export {
+  limitFunctionCallCount,
+};

--- a/js-exercises/limit-function-call-count/limitFunctionCallCount.test.js
+++ b/js-exercises/limit-function-call-count/limitFunctionCallCount.test.js
@@ -1,0 +1,21 @@
+import { limitFunctionCallCount } from './limitFunctionCallCount';
+
+describe('limitFunctionCallCount', () => {
+  it('should return a function', () => {
+    expect(typeof limitFunctionCallCount()).toBe('function');
+  });
+  it('should return a wrapped version of the original function that can only be invoked n times', () => {
+    const foo = () => (true);
+    const limitedFunction = limitFunctionCallCount(foo, 2);
+    expect(limitedFunction()).toBe(true);
+    limitedFunction();
+    expect(limitedFunction()).toBe(null);
+  });
+  it('should properly handle arguments in the wrapped function', () => {
+    const foo = (x, y, z) => (x + y + z);
+    const limitedFunction = limitFunctionCallCount(foo, 2);
+    expect(limitedFunction(5, 10, 15)).toBe(30);
+    limitedFunction(0, 0, 0);
+    expect(limitedFunction()).toBe(null);
+  });
+});

--- a/js-exercises/math-fns/README.md
+++ b/js-exercises/math-fns/README.md
@@ -1,0 +1,3 @@
+# Instructions
+
+See the `mathFns.js` file.

--- a/js-exercises/math-fns/mathFns.js
+++ b/js-exercises/math-fns/mathFns.js
@@ -1,0 +1,15 @@
+/* eslint-disable prefer-destructuring */
+// You can use the function from the `Math` module.
+
+const sqrt = Math.sqrt;
+
+const power = (x, y) => x ** y;
+
+const round = Math.round;
+
+// Don't change the exported names.
+export {
+  sqrt,
+  power,
+  round,
+};

--- a/js-exercises/math-fns/mathFns.test.js
+++ b/js-exercises/math-fns/mathFns.test.js
@@ -1,0 +1,9 @@
+import { sqrt, power, round } from './mathFns';
+
+describe('Use Math functions', () => {
+  test('should use the math functions to get correct values', () => {
+    expect(sqrt(49)).toBe(7);
+    expect(power(2, 4)).toBe(16);
+    expect(round(7.4)).toBe(7);
+  });
+});


### PR DESCRIPTION
For mathFns.js the eslint issue was popping. i.e "An intrinsic object that provides basic mathematics functionality and constants.
Use object destructuring."
Was unable to solve it. So added 
/* eslint-disable prefer-destructuring */

